### PR TITLE
Add meta tags for Mastodon validation and reference

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -25,6 +25,8 @@ const App = ({ Component, pageProps }) => {
         <StripeProvider>
           <Head>
             <title>Associazione Python Italia</title>
+            <meta content="@pythonitalia@social.python.it" name="fediverse:creator">
+            <link href="https://social.python.it/@pythonitalia" rel="me" />
             <link rel="icon" href="/favicon.png" />
             <link
               href="https://fonts.googleapis.com/css?family=Montserrat:300,700"


### PR DESCRIPTION
## Why

Add meta tags to verify the back link in the Mastodon account, and to be marked as creator when people share some Python Ialia links.

## How to test it

After the merge and the deploy go to the Mastodon account (https://social.python.it/@pythonitalia) and check the green check mark :heavy_check_mark: right close to the URL.